### PR TITLE
feat: Add Edit Item functionality (UI + API)

### DIFF
--- a/db.json
+++ b/db.json
@@ -64,6 +64,11 @@
       "id": "f432",
       "name": "fffyyu",
       "quantity": 5
+    },
+    {
+      "id": "be1e",
+      "name": "coffee",
+      "quantity": 10
     }
   ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import './App.css';
 import ItemList from './components/ItemList';
 import AddItemForm from './components/AddItemForm';
 import { Container, TextField } from '@mui/material';
+import EditItemForm from './components/EditItemForm';
+
 
 
 
@@ -20,6 +22,12 @@ const API_URL = 'http://localhost:5000/items';
 function App() {
   const [items, setItems] = useState<Item[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
+  const [editingItem, setEditingItem] = useState<Item | null>(null);
+  const handleEditClick = (item: Item) => {
+    setEditingItem(item);
+  };
+  
+
 
 
   // ✅ 1. Load items from API
@@ -60,6 +68,24 @@ function App() {
       })
       .catch((err) => console.error('Failed to delete item:', err));
   };
+  // ✅ 4. Update item in API
+const handleUpdateItem = (updatedItem: { id: number; name: string; quantity: number }) => {
+  fetch(`${API_URL}/${updatedItem.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updatedItem),
+  })
+    .then((res) => res.json())
+    .then((data) => {
+      setItems((prev) =>
+        prev.map((item) => (item.id === updatedItem.id ? data : item))
+      );
+      setEditingItem(null); // ✅ hide form after update
+      console.log('[PUT] Updated:', data);
+    })
+    .catch((err) => console.error('Failed to update item:', err));
+};
+
   const filteredItems = searchTerm
   ? items.filter((item) =>
       item.name.toLowerCase().includes(searchTerm.toLowerCase())
@@ -74,8 +100,17 @@ function App() {
         </div>
     
         <div style={{ marginBottom: '24px' }}>
-          <AddItemForm onAddItem={handleAddItem} />
-        </div>
+  {editingItem ? (
+    <EditItemForm
+      item={editingItem}
+      onUpdate={handleUpdateItem}
+      onCancel={() => setEditingItem(null)}
+    />
+  ) : (
+    <AddItemForm onAddItem={handleAddItem} />
+  )}
+</div>
+
     
         <div style={{ marginBottom: '24px' }}>
           <TextField
@@ -88,7 +123,7 @@ function App() {
         </div>
     
         <div>
-          <ItemList items={filteredItems} onDelete={handleDeleteItem} />
+          <ItemList items={filteredItems} onDelete={handleDeleteItem}  onEdit={handleEditClick} />
         </div>
       </Container>
     );

--- a/src/components/EditItemForm.tsx
+++ b/src/components/EditItemForm.tsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Button, TextField, Typography } from '@mui/material';
+
+type EditItemFormProps = {
+  item: {
+    id: number;
+    name: string;
+    quantity: number;
+  };
+  onUpdate: (updatedItem: { id: number; name: string; quantity: number }) => void;
+  onCancel: () => void;
+};
+
+const EditItemForm: React.FC<EditItemFormProps> = ({ item, onUpdate, onCancel }) => {
+  const [name, setName] = useState(item.name);
+  const [quantity, setQuantity] = useState(item.quantity.toString());
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!name.trim() || isNaN(Number(quantity)) || Number(quantity) <= 0) {
+      alert('Please enter a valid name and quantity.');
+      return;
+    }
+
+    onUpdate({ id: item.id, name, quantity: Number(quantity) });
+  };
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{ display: 'flex', gap: 2, alignItems: 'center', marginBottom: 4 }}
+    >
+      <Typography variant="h6">Edit Item:</Typography>
+      <TextField
+        label="Item Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        required
+      />
+      <TextField
+        label="Quantity"
+        type="number"
+        value={quantity}
+        onChange={(e) => setQuantity(e.target.value)}
+        required
+      />
+      <Button type="submit" variant="contained" color="primary">
+        Update
+      </Button>
+      <Button variant="outlined" onClick={onCancel}>
+        Cancel
+      </Button>
+    </Box>
+  );
+};
+
+export default EditItemForm;

--- a/src/components/ItemList.tsx
+++ b/src/components/ItemList.tsx
@@ -8,6 +8,8 @@ import {
   Paper,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+
 
 type Item = {
   id: number;
@@ -18,9 +20,11 @@ type Item = {
 type ItemListProps = {
   items: Item[];
   onDelete: (id: number) => void;
+  onEdit: (item: Item) => void;
 };
 
-const ItemList: React.FC<ItemListProps> = ({ items, onDelete }) => {
+const ItemList: React.FC<ItemListProps> = ({ items, onDelete, onEdit }) => {
+
   return (
     <Paper elevation={3} sx={{ padding: 2 }}>
       <Typography variant="h6" gutterBottom>
@@ -31,10 +35,15 @@ const ItemList: React.FC<ItemListProps> = ({ items, onDelete }) => {
           <ListItem
             key={item.id}
             secondaryAction={
-              <IconButton edge="end" onClick={() => onDelete(item.id)}>
-                <DeleteIcon />
-              </IconButton>
-            }
+              <>
+    <IconButton edge="end" onClick={() => onEdit(item)}>
+  <EditIcon />
+</IconButton>
+    <IconButton edge="end" onClick={() => onDelete(item.id)}>
+      <DeleteIcon />
+    </IconButton>
+  </>
+}
           >
             <ListItemText
               primary={item.name}


### PR DESCRIPTION
### What I Did

- Added an "Edit" button next to each item in the list
- Created a new `EditItemForm` component using Material UI
- Allows editing item name and quantity
- Sends PUT request to update item on the server
- Replaces Add form with Edit form when editing starts
- Returns to Add form after update or cancel

### Why I Did It

To allow users to modify existing items directly from the UI. This is a common real-world use case in inventory or robotics dashboard apps.

### Testing

- ✅ Tested editing name and quantity of an item
- ✅ Confirmed PUT request updates the backend
- ✅ Cancel button hides the edit form and restores add form